### PR TITLE
Build in support for Prettier and Black

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -31,11 +31,22 @@ local function has_config_file(filename)
 	return false
 end
 
+local function get_prettier_parser()
+	-- Most parsers are the same as the lexer name
+	local parser = buffer:get_lexer()
+	if parser == 'javascript' then
+		parser = 'babel'
+	end
+	return has_config_file('package.json') and 'npx prettier --parser ' .. parser or nil
+end
+
 --- Map of lexer languages to string code formatter commands or functions that return such
 -- commands.
 M.commands = {
 	lua = function() return has_config_file('.lua-format') and 'lua-format' or nil end,
 	cpp = function() return has_config_file('.clang-format') and 'clang-format -style=file' or nil end,
+	html = get_prettier_parser, css = get_prettier_parser, javascript = get_prettier_parser,
+	markdown = get_prettier_parser, yaml = get_prettier_parser,
 	go = 'gofmt', dart = 'dart format', python = 'black -'
 }
 M.commands.c = M.commands.cpp

--- a/init.lua
+++ b/init.lua
@@ -47,7 +47,7 @@ M.commands = {
 	cpp = function() return has_config_file('.clang-format') and 'clang-format -style=file' or nil end,
 	html = get_prettier_parser, css = get_prettier_parser, javascript = get_prettier_parser,
 	markdown = get_prettier_parser, yaml = get_prettier_parser,
-	go = 'gofmt', dart = 'dart format', python = 'black -'
+	go = 'gofmt', dart = 'dart format', python = ((WIN32 and 'py' or 'python') .. ' -m black -')
 }
 M.commands.c = M.commands.cpp
 

--- a/init.lua
+++ b/init.lua
@@ -21,11 +21,21 @@ local M = {}
 
 --- Helper function that returns whether or not the given config file exists in the current or
 -- a parent directory of the current buffer's filename.
-local function has_config_file(filename)
+local function has_config_file(filename, contains)
 	if not buffer.filename then return false end
 	local dir = buffer.filename:match('^(.+)[/\\]')
 	while dir do
-		if lfs.attributes(dir .. '/' .. filename) then return true end
+		if lfs.attributes(dir .. '/' .. filename) then
+			if not contains then return true
+			else
+				local f = io.open(dir .. '/' .. filename, mode)
+				if f then
+					local found = f:read('a'):match(contains)
+					f:close()
+					if found then return true end
+				end
+			end
+		end
 		dir = dir:match('^(.+)[/\\]')
 	end
 	return false
@@ -37,7 +47,7 @@ local function get_prettier_parser()
 	if parser == 'javascript' then
 		parser = 'babel'
 	end
-	return has_config_file('package.json') and 'npx prettier --parser ' .. parser or nil
+	return has_config_file('package.json', 'prettier') and 'npx prettier --parser ' .. parser or nil
 end
 
 --- Map of lexer languages to string code formatter commands or functions that return such

--- a/init.lua
+++ b/init.lua
@@ -62,7 +62,7 @@ M.commands = {
 		if has_config_file('ruff.toml') or has_config_file('pyproject.toml', 'ruff') then
 			return 'ruff format -'
 		else
-			return ((WIN32 and 'py' or 'python') .. ' -m black -')
+			return ((WIN32 and 'py -m ' or '') .. 'black -')
 		end
 	end
 }

--- a/init.lua
+++ b/init.lua
@@ -57,7 +57,14 @@ M.commands = {
 	cpp = function() return has_config_file('.clang-format') and 'clang-format -style=file' or nil end,
 	html = get_prettier_parser, css = get_prettier_parser, javascript = get_prettier_parser,
 	markdown = get_prettier_parser, yaml = get_prettier_parser,
-	go = 'gofmt', dart = 'dart format', python = ((WIN32 and 'py' or 'python') .. ' -m black -')
+	go = 'gofmt', dart = 'dart format',
+	python = function ()
+		if has_config_file('ruff.toml') or has_config_file('pyproject.toml', 'ruff') then
+			return 'ruff format -'
+		else
+			return ((WIN32 and 'py' or 'python') .. ' -m black -')
+		end
+	end
 }
 M.commands.c = M.commands.cpp
 

--- a/init.lua
+++ b/init.lua
@@ -36,7 +36,7 @@ end
 M.commands = {
 	lua = function() return has_config_file('.lua-format') and 'lua-format' or nil end,
 	cpp = function() return has_config_file('.clang-format') and 'clang-format -style=file' or nil end,
-	go = 'gofmt', dart = 'dart format'
+	go = 'gofmt', dart = 'dart format', python = 'black -'
 }
 M.commands.c = M.commands.cpp
 


### PR DESCRIPTION
As per the title. No worries if you don't want to merge.

I chose Black as it is by the [Python Software Foundation](https://www.python.org/psf-landing/) and hence arguably the standard, though a lot of people seem to like [Ruff](https://docs.astral.sh/ruff/formatter/) these days.